### PR TITLE
Feature/v1.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@astraload/profilers",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@astraload/profilers",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "CPU profiler and heap dumper for multi-instance Meteor applications",
   "main": "index.js",
   "scripts": {},

--- a/src/cpu-profiler.js
+++ b/src/cpu-profiler.js
@@ -61,7 +61,8 @@ class CpuProfiler {
       const result = profileExportFiber();
       const fileName = this.getFileNameById(id);
       const filePath = this.getFilePathByName(fileName);
-      fs.writeFileSync(filePath, result);
+      const writeFileFiber = Meteor.wrapAsync(fs.writeFile, fs);
+      writeFileFiber(filePath, result);
       return { fileName, filePath };
     } catch (error) {
       console.error(`Failed to save CPU profile (${id})`, error);


### PR DESCRIPTION
Write CPU profile and heap snapshot to disk asynchronously.
Make `handleTaskAdded` function synchronous.
Rename HeapDumper's `snapshot` method to `takeSnapshot` and wrap it with try...catch.