### PR TITLE
Suppress possible createIndex error

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -5,7 +5,7 @@ let InstanceTasks = null;
 
 function createCollection() {
   InstanceTasks = new Mongo.Collection(CollectionName);
-  InstanceTasks.rawCollection().createIndex({ instanceName: 1 });
+  InstanceTasks.rawCollection().createIndex({ instanceName: 1 }).catch(() => {});
   InstanceTasks.deny({
     insert() { return true; },
     update() { return true; },


### PR DESCRIPTION
`createIndex` command can throw an error in case `authorization` is enabled in MongoDB and the user that the app uses to connect to MongoDB doesn't have the [`createIndex`](https://docs.mongodb.com/manual/reference/privilege-actions/#mongodb-authaction-createIndex) privilege. We choose to suppress that error since the index is optional